### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hugo-fastmail.yml
+++ b/.github/workflows/hugo-fastmail.yml
@@ -7,6 +7,8 @@ on:
   schedule:
     - cron: "23 6 * * *"
   workflow_dispatch:
+permissions:
+  contents: read
 concurrency:
   group: "pages"
   cancel-in-progress: false


### PR DESCRIPTION
Potential fix for [https://github.com/freiheit/freiheit-wtf/security/code-scanning/2](https://github.com/freiheit/freiheit-wtf/security/code-scanning/2)

In general, this issue is fixed by adding an explicit `permissions` block to the workflow (either at the top level, applying to all jobs, or per job) and setting it to the minimal required scopes. For build/deploy workflows that only need to read repository contents, a typical minimal configuration is `permissions: contents: read` at the workflow root. Additional scopes (like `id-token: write` or `pull-requests: write`) are only added when strictly needed.

For this specific workflow in `.github/workflows/hugo-fastmail.yml`, neither `build` nor `deploy` modifies repository contents, issues, or pull requests; they simply read the code, build it, store artifacts, and interact with an external WebDAV service via secrets. Therefore, a single top-level `permissions` block with `contents: read` is sufficient and will not change existing functionality. The best fix is to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `concurrency:` block. This will apply to all jobs (`build` and `deploy`) unless they define their own `permissions` (which they do not). No imports, extra methods, or additional configuration files are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
