### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: pre-commit
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/freiheit/freiheit-wtf/security/code-scanning/3](https://github.com/freiheit/freiheit-wtf/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block that grants only the scopes required by this workflow. Since this job just checks out code and runs pre-commit hooks, it only needs read access to repository contents. It doesn’t need to write to the repo, open issues, or modify PRs.

The best minimal change without altering functionality is to add `permissions: contents: read` at the workflow level, so it applies to all jobs in this file. Concretely, in `.github/workflows/pre-commit.yml`, insert a `permissions:` block after the `name:` and before the `on:` section:

```yaml
name: pre-commit
permissions:
  contents: read

on:
  ...
```

No imports or additional definitions are required, as this is pure GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
